### PR TITLE
Add setup.py and update installation intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,16 @@ python -m pip install -r requirements.txt
 If you have any installation problems for Jittor, please refer to [Jittor](https://github.com/Jittor/jittor)
 
 **Step 2: Install JNeRF**
- 
-You can add ```export PYTHONPATH=$PYTHONPATH:{your_path_to_jnerf}/JNeRF/python``` into ```~/.bashrc```, and run
+
+JNeRF is a benchmark toolkit and can be updated frequently, so installing in editable mode is recommended.
+Thus any modifications made to JNeRF will take effect without reinstallation.
+
 ```shell
-source ~/.bashrc
+cd python
+python -m pip install -e .
 ```
+
+After installation, you can ```import jnerf``` in python interpreter to check if it is successful or not.
 
 ## Getting Started
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,20 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="jnerf",
+    version="0.1",
+    description="instance-ngp and nerf benchmark base on jittor",
+    author="jittor team, g2 lab, tsinghua university",
+    url="https://github.com/Jittor/JNeRF",
+    packages=find_packages(),
+    install_requires=[
+        "jittor>=1.3.4.13",
+        "numpy",
+        "tqdm",
+        "opencv-python",
+        "Pillow",
+        "imageio",
+        "pyyaml"
+    ]
+)
+


### PR DESCRIPTION
As a benchmark toolkit, to our best practice, it is recommended to install the main package with pip "editable mode".
Here adds a setup.py script which can support pip command.
The installation intro in README has updated as well.

Please check the package information (setup function) and update according to the Jittor and JNeRF team.