### PR TITLE
fix cudaErrorIllegalAddress

### DIFF
--- a/python/jnerf/models/position_encoders/hash_encoder/hash_encoder.py
+++ b/python/jnerf/models/position_encoders/hash_encoder/hash_encoder.py
@@ -10,12 +10,13 @@ class HashEncoder(nn.Module):
         self.cfg = get_cfg()
         using_fp16 = self.cfg.fp16
         aabb_scale = self.cfg.dataset_obj.aabb_scale
+        n_rays_per_batch = self.cfg.n_rays_per_batch
         self.hash_func = self.cfg.hash_func
         self.hash_func_header = f"""
 #define get_index(p0,p1,p2) {self.hash_func}
         """
         self.encoder = GridEncode(self.hash_func_header, aabb_scale=aabb_scale, n_pos_dims=3, n_features_per_level=2,
-                                  n_levels=16, base_resolution=16, log2_hashmap_size=19, using_fp16=using_fp16)
+                                  n_levels=16, base_resolution=16, log2_hashmap_size=19, using_fp16=using_fp16, n_rays_per_batch=n_rays_per_batch)
         self.grad_type = 'float32'
         if using_fp16:
             self.grad_type = 'float16'


### PR DESCRIPTION
Use `cfg.n_rays_per_batch`  instead of default `n_rays_per_batch` 4096 in `JNeRF/python/jnerf/models/position_encoders/hash_encoder/grid_encode.py` which may cause cudaErrorIllegalAddress below when  `cfg.n_rays_per_batch` much greater than 4096.
```
code=700( cudaErrorIllegalAddress ) cudaMemcpy(a.ptr, var->mem_ptr, var->size, cudaMemcpyDeviceToHost)
```