### PR TITLE
add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y upgrade \
+    && apt-get -y install --no-install-recommends libgl1 tcl-dev tk-dev python3 python-is-python3 python3-pip python3-tk python3-dev git
+
+COPY ./requirements.txt ./
+
+RUN python3 -m pip install -U pip \
+	&& pip3 --no-cache-dir install -r ./requirements.txt \
+	&& rm ./requirements.txt

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,8 @@
+# Dev Container
+
+Prepared base environment for evaluation and development in VS Code Dev Container. After cloning the repo and opened it in Dev Container, you can install and run `jnerf` directly.
+
+```shell
+cd python
+python -m pip install -e .
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "JNeRF Dev Container",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "jnerf",
+    "workspaceFolder": "/volume",
+    "shutdownAction": "stopCompose",
+    "extensions": [
+        "ms-python.python"
+    ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  jnerf:
+    image: jnerf-dev-container:latest
+    build:
+      context: ..
+      dockerfile: ./.devcontainer/Dockerfile
+    stdin_open: true
+    tty: true
+    volumes:
+      - ../:/volume
+    working_dir: /volume
+    command: /bin/bash
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]


### PR DESCRIPTION
Add devcontainer support to simplify JNeRF running and development. Users now can directly open a prepared environment for JNeRF with vscode on both Linux and Windows (with WSL).